### PR TITLE
Use BUNDLE environment in Webpack config to prevent certain Marko cod…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,7 +109,12 @@ module.exports = [
     },
     plugins: [
       new webpack.optimize.OccurrenceOrderPlugin(),
-      new webpack.NoEmitOnErrorsPlugin()
+      new webpack.NoEmitOnErrorsPlugin(),
+      new webpack.DefinePlugin({
+        'process.env': {
+          BUNDLE: 'true'
+        }
+      })
     ]
   }
 ];


### PR DESCRIPTION
…e from getting bundled in.

In response to: https://github.com/marko-js/marko/issues/702

Looks like there's some Marko code getting bundled in by webpack that shouldn't be since `marko@4.4.0`. This is a partial fix to prevent this from happening. Ultimately, this will require a fix in Marko, but this should hold you over.

